### PR TITLE
Update WGSLColours.java

### DIFF
--- a/src/main/java/wgslplugin/language/WGSLColours.java
+++ b/src/main/java/wgslplugin/language/WGSLColours.java
@@ -15,7 +15,7 @@ public enum WGSLColours {
     BLOCK_COMMENT("Block comment", createTextAttributesKey("WGSL_BLOCK_COMMENT", DefaultLanguageHighlighterColors.BLOCK_COMMENT)),
     DOC_COMMENT("Documentation comment", createTextAttributesKey("WGSL_DOC_COMMENT", DefaultLanguageHighlighterColors.DOC_COMMENT)),
     BUILTIN_FUNCTION("Built-in function", DefaultLanguageHighlighterColors.STATIC_METHOD),
-    BUILTIN_TYPE("Built-in type", createTextAttributesKey("WGSL_TYPE", DefaultLanguageHighlighterColors.CLASS_NAME)),
+    BUILTIN_TYPE("Built-in type", createTextAttributesKey("WGSL_TYPE", DefaultLanguageHighlighterColors.KEYWORD)),
     TEXEL_FORMAT("Texel format", createTextAttributesKey("WGSL_TEXEL_FORMAT", DefaultLanguageHighlighterColors.CLASS_NAME)),
     PARENTHESIS("Parenthesis", createTextAttributesKey("WGSL_PAREN", DefaultLanguageHighlighterColors.PARENTHESES)),
     BRACES("Braces", createTextAttributesKey("WGSL_BRACE", DefaultLanguageHighlighterColors.BRACES)),


### PR DESCRIPTION
I don't know if you would consider making the keywords of wgsl to default to the keyword color. This seems to be the default and will make scanning the wgsl files for types easier :) . Otherwise I like the plugin.