### PR TITLE
Struct member separator is comma instead of semicolon

### DIFF
--- a/src/main/java/wgslplugin/language/wgsl.bnf
+++ b/src/main/java/wgslplugin/language/wgsl.bnf
@@ -71,7 +71,7 @@ struct_body_decl ::=
       BRACE_LEFT struct_member* BRACE_RIGHT
 
 struct_member ::=
-      attribute_list* field SEMICOLON
+      attribute_list* field COMMA
 
 field ::= field_ident COLON type_decl
 


### PR DESCRIPTION
Maybe all it takes to solve https://github.com/dparnell/intellij-wgsl/issues/18, though I haven't tested it. Happy to test if there is a link on how to build and add a WebStorm / IDEA plugin from source.