### PR TITLE
Add custom imports from URLs to completions

### DIFF
--- a/src/main/java/wgslplugin/language/WGSLAddURLDialogWrapper.java
+++ b/src/main/java/wgslplugin/language/WGSLAddURLDialogWrapper.java
@@ -1,0 +1,67 @@
+package wgslplugin.language;
+
+import com.intellij.openapi.ui.ComponentValidator;
+import com.intellij.openapi.ui.DialogPanel;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class WGSLAddURLDialogWrapper extends DialogWrapper {
+    protected JTextField textField = new JTextField();
+    protected String getFieldData() {
+        return textField.getText();
+    }
+    protected ComponentValidator componentValidator = new ComponentValidator(getDisposable())
+            .withValidator(() -> {
+                String pt = textField.getText();
+                if (StringUtil.isNotEmpty(pt)) {
+                    try {
+                        if (!new URL(pt).getFile().endsWith(".wgsl")) throw new MalformedURLException();
+                    } catch (MalformedURLException e) {
+                        return new ValidationInfo("Specify correct URL with file extension", textField);
+                    }
+                    return null;
+                } else {
+                    return new ValidationInfo("URL cannot be a blank string", textField);
+                }
+            });
+
+    public WGSLAddURLDialogWrapper() {
+        super(true);
+        setTitle("Add Source URL");
+        textField.setText("");
+        textField.setPreferredSize(new Dimension(300, textField.getHeight()));
+        init();
+    }
+
+    public WGSLAddURLDialogWrapper(String defaultText) {
+        super(true);
+        setTitle("Add Source URL");
+        textField.setText(defaultText);
+        textField.setPreferredSize(new Dimension(300, textField.getHeight()));
+        init();
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        DialogPanel dialogPanel = new DialogPanel(new BorderLayout());
+
+        dialogPanel.add(textField, BorderLayout.CENTER);
+        dialogPanel.setPreferredFocusedComponent(textField);
+
+        return dialogPanel;
+    }
+
+    @Nullable
+    protected ValidationInfo doValidate() {
+        componentValidator.revalidate();
+        return componentValidator.getValidationInfo();
+    }
+}

--- a/src/main/java/wgslplugin/language/WGSLBuiltInCompletionContributor.java
+++ b/src/main/java/wgslplugin/language/WGSLBuiltInCompletionContributor.java
@@ -12,11 +12,15 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.ui.LayeredIcon;
 import org.jetbrains.annotations.NotNull;
+import wgslplugin.language.psi.*;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class WGSLBuiltInCompletionContributor extends CompletionContributor {
 
@@ -37,26 +41,109 @@ public class WGSLBuiltInCompletionContributor extends CompletionContributor {
             return new HashSet<>();
         }
 
-        BuiltInFunctions.INSTANCE.get(element);
-        return BuiltInFunctions.INSTANCE.functions.values().stream()
-                .filter(x -> x.getFunctionHeader().getFunctionName().getName() != null && x.getFunctionHeader().getParamList() != null)
-                .map(x -> {
-                    var name = x.getFunctionHeader().getFunctionName().getName();
-                    var params = x.getFunctionHeader().getParamList().getParamList().stream()
-                            .filter(y -> y.getVariableIdentDecl().getTypeDecl() != null)
-                            .map(y -> y.getVariableIdentDecl().getName() + ": " + y.getVariableIdentDecl().getTypeDecl().getText()
-                    ).collect(Collectors.toList());
-                    return createStaticMethod(name, params);
+        Predicate<? super WGSLFunctionDecl> funcFilter = (x) ->
+                x.getFunctionHeader().getFunctionName().getName() != null && x.getFunctionHeader().getParamList() != null;
 
-                }).collect(Collectors.toSet());
+        Predicate<? super WGSLGlobalConstantDecl> constFilter = (x) ->
+                x.getVariableIdentDecl().getName() != null && x.getVariableIdentDecl().getTypeDecl() != null;
+
+        Predicate<? super WGSLGlobalVariableDecl> variableFilter = (x) ->
+                x.getVariableDecl().getVariableIdentDecl().getName() != null && x.getVariableDecl().getVariableIdentDecl().getTypeDecl() != null;
+
+        Predicate<? super WGSLStructDecl> structFilter = (x) ->
+                x.getNode().findChildByType(WGSLTypes.IDENT) != null;
+
+        Function<WGSLFunctionDecl, LookupElement> staticFuncMapper = (x) -> {
+            var name = x.getFunctionHeader().getFunctionName().getName();
+            var params = x.getFunctionHeader().getParamList().getParamList().stream()
+                    .filter(y -> y.getVariableIdentDecl().getTypeDecl() != null)
+                    .map(y -> y.getVariableIdentDecl().getName() + ": " + y.getVariableIdentDecl().getTypeDecl().getText()
+                    ).collect(Collectors.toList());
+            return createStaticMethod(name, params);
+        };
+
+        Function<WGSLFunctionDecl, LookupElement> regularFuncMapper = (x) -> {
+            var name = x.getFunctionHeader().getFunctionName().getName();
+            var params = x.getFunctionHeader().getParamList().getParamList().stream()
+                    .filter(y -> y.getVariableIdentDecl().getTypeDecl() != null)
+                    .map(y -> y.getVariableIdentDecl().getName() + ": " + y.getVariableIdentDecl().getTypeDecl().getText()
+                    ).collect(Collectors.toList());
+            return createRegularMethod(name, params);
+        };
+
+        Function<WGSLGlobalConstantDecl, LookupElement> globalConstMapper = (x) -> {
+            var name = x.getVariableIdentDecl().getName();
+            var type = x.getVariableIdentDecl().getTypeDecl().getText();
+            return createGlobalConstant(name, type);
+        };
+
+        Function<WGSLGlobalVariableDecl, LookupElement> globalVariableMapper = (x) -> {
+            var name = x.getVariableDecl().getVariableIdentDecl().getName();
+            var type = x.getVariableDecl().getVariableIdentDecl().getTypeDecl().getText();
+            return createGlobalVariable(name, type);
+        };
+
+        Function<WGSLStructDecl, LookupElement> structMapper = (x) -> {
+            var name = x.getNode().findChildByType(WGSLTypes.IDENT).getText();
+            return createStruct(name);
+        };
+
+        BuiltInFunctions.INSTANCE.get(element);
+        WGSLCustomImportsFetcher.INSTANCE.get(element);
+
+        return Stream.of(
+                BuiltInFunctions.INSTANCE.functions.values().stream()
+                        .filter(funcFilter)
+                        .map(staticFuncMapper).collect(Collectors.toSet())
+                        .stream()
+                , WGSLCustomImportsFetcher.INSTANCE.functions.values().stream()
+                        .filter(funcFilter)
+                        .map(regularFuncMapper).collect(Collectors.toSet())
+                        .stream()
+                , WGSLCustomImportsFetcher.INSTANCE.constants.values().stream()
+                        .filter(constFilter)
+                        .map(globalConstMapper).collect(Collectors.toSet())
+                        .stream()
+                , WGSLCustomImportsFetcher.INSTANCE.variables.values().stream()
+                        .filter(variableFilter)
+                        .map(globalVariableMapper).collect(Collectors.toSet())
+                        .stream()
+                , WGSLCustomImportsFetcher.INSTANCE.structs.values().stream()
+                        .filter(structFilter)
+                        .map(structMapper).collect(Collectors.toSet())
+                        .stream()
+        ).flatMap(i -> i).collect(Collectors.toSet());
     }
 
     private LookupElement createStaticMethod(String name, List<String> arguments) {
-        // System.out.println("Static: " + name);
         return LookupElementBuilder.create(name)
                 .withIcon(new LayeredIcon(AllIcons.Nodes.Method, AllIcons.Nodes.StaticMark))
                 .withTailText("(" + String.join(", ", arguments) + ")")
                 .withInsertHandler(WITH_PARAMETERS);
+    }
+
+    private LookupElement createRegularMethod(String name, List<String> arguments) {
+        return LookupElementBuilder.create(name)
+                .withIcon(new LayeredIcon(AllIcons.Nodes.Method))
+                .withTailText("(" + String.join(", ", arguments) + ")")
+                .withInsertHandler(WITH_PARAMETERS);
+    }
+
+    private LookupElement createGlobalConstant(String name, String type) {
+        return LookupElementBuilder.create(name)
+                .withIcon(new LayeredIcon(AllIcons.Nodes.Constant))
+                .withTailText(":" + type);
+    }
+
+    private LookupElement createGlobalVariable(String name, String type) {
+        return LookupElementBuilder.create(name)
+                .withIcon(new LayeredIcon(AllIcons.Nodes.Variable))
+                .withTailText(":" + type);
+    }
+
+    private LookupElement createStruct(String name) {
+        return LookupElementBuilder.create(name)
+                .withIcon(new LayeredIcon(AllIcons.Nodes.Class, AllIcons.Nodes.StaticMark));
     }
 
 }

--- a/src/main/java/wgslplugin/language/WGSLCustomImportsFetcher.java
+++ b/src/main/java/wgslplugin/language/WGSLCustomImportsFetcher.java
@@ -24,7 +24,7 @@ public class WGSLCustomImportsFetcher {
     public Map<String, WGSLStructDecl> structs = new HashMap<>();
 
     public synchronized WGSLFunctionDecl get(PsiElement element) {
-        List<String> customImports = WGSLSettingsState.getInstance().customImports;
+        List<String> customImports = WGSLSettingsState.getInstance(element.getProject()).customImports;
 
         if (!customImportsCached.equals(customImports)) {
             customImportsCached.addAll(customImports);

--- a/src/main/java/wgslplugin/language/WGSLCustomImportsFetcher.java
+++ b/src/main/java/wgslplugin/language/WGSLCustomImportsFetcher.java
@@ -1,0 +1,92 @@
+package wgslplugin.language;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import wgslplugin.language.psi.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class WGSLCustomImportsFetcher {
+    public static final WGSLCustomImportsFetcher INSTANCE = new WGSLCustomImportsFetcher();
+    private final List<PsiFile> dummyFiles = new ArrayList<>();
+    private final List<String> customImportsCached = new ArrayList<>();
+    public Map<String, WGSLFunctionDecl> functions = new HashMap<>();
+    public Map<String, WGSLGlobalConstantDecl> constants = new HashMap<>();
+    public Map<String, WGSLGlobalVariableDecl> variables = new HashMap<>();
+    public Map<String, WGSLStructDecl> structs = new HashMap<>();
+
+    public synchronized WGSLFunctionDecl get(PsiElement element) {
+        List<String> customImports = WGSLSettingsState.getInstance().customImports;
+
+        if (!customImportsCached.equals(customImports)) {
+            customImportsCached.addAll(customImports);
+            dummyFiles.clear();
+            functions.clear();
+            constants.clear();
+            variables.clear();
+            structs.clear();
+        }
+
+        if (dummyFiles.isEmpty()) {
+            for (String customImport : customImports) {
+                try
+                {
+                    URL url = new URL(customImport);
+                    URLConnection urlConnection = url.openConnection();
+                    InputStream inputStream = urlConnection.getInputStream();
+
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    byte[] buf = new byte[16384];
+                    int L = inputStream.read(buf);
+                    while(L>0) {
+                        bos.write(buf, 0, L);
+                        L = inputStream.read(buf);
+                    }
+                    PsiFile dummyFile = WGSLElementFactory.createFile(element.getProject(), bos.toString("UTF-8"));
+                    dummyFiles.add(dummyFile);
+
+                    PsiElement[] customFunctions = PsiTreeUtil.collectElements(dummyFile, e -> e instanceof WGSLFunctionDecl);
+                    for(PsiElement func : customFunctions) {
+                        WGSLFunctionDecl f = (WGSLFunctionDecl) func;
+                        String name = f.getFunctionHeader().getFunctionName().getName();
+                        functions.put(name, f);
+                    }
+
+                    PsiElement[] customConstants = PsiTreeUtil.collectElements(dummyFile, e -> e instanceof WGSLGlobalConstantDecl);
+                    for(PsiElement constant : customConstants) {
+                        WGSLGlobalConstantDecl c = (WGSLGlobalConstantDecl) constant;
+                        String name = c.getVariableIdentDecl().getName();
+                        constants.put(name, c);
+                    }
+
+                    PsiElement[] customVariables = PsiTreeUtil.collectElements(dummyFile, e -> e instanceof WGSLGlobalVariableDecl);
+                    for(PsiElement variable : customVariables) {
+                        WGSLGlobalVariableDecl v = (WGSLGlobalVariableDecl) variable;
+                        String name = v.getVariableDecl().getVariableIdentDecl().getName();
+                        variables.put(name, v);
+                    }
+
+                    PsiElement[] customStructs = PsiTreeUtil.collectElements(dummyFile, e -> e instanceof WGSLStructDecl);
+                    for(PsiElement struct : customStructs) {
+                        WGSLStructDecl s = (WGSLStructDecl) struct;
+                        String name = s.getNode().findChildByType(WGSLTypes.IDENT).getText(); // FIXME: extend WGSLStructDecl with getName()
+                        structs.put(name, s);
+                    }
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                    return null;
+                }
+            }
+        }
+
+        return functions.get(element.getText());
+    }
+}

--- a/src/main/java/wgslplugin/language/WGSLSettingsComponent.java
+++ b/src/main/java/wgslplugin/language/WGSLSettingsComponent.java
@@ -1,0 +1,70 @@
+package wgslplugin.language;
+
+import com.intellij.ui.*;
+import com.intellij.ui.components.JBList;
+import com.intellij.util.ui.FormBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.List;
+
+public class WGSLSettingsComponent {
+    private final JPanel myMainPanel;
+    private final CollectionListModel<String> myCustomImports = new CollectionListModel<>();
+    private final JBList<String> myList = new JBList<>(myCustomImports);
+
+    public WGSLSettingsComponent() {
+        ToolbarDecorator myToolbar = ToolbarDecorator.createDecorator(myList);
+        myToolbar.disableUpDownActions();
+        ColoredListCellRenderer<String> cellRenderer = new ColoredListCellRenderer<>() {
+            @Override
+            protected void customizeCellRenderer(
+                    @NotNull JList<? extends String> list, String value,
+                    int index, boolean selected, boolean hasFocus
+            ) {
+                append(value, SimpleTextAttributes.LINK_PLAIN_ATTRIBUTES);
+            }
+        };
+        myList.setCellRenderer(cellRenderer);
+        AnActionButtonRunnable addAction = (AnActionButton actionButton) -> {
+            WGSLAddURLDialogWrapper dialogWrapper = new WGSLAddURLDialogWrapper();
+            if (dialogWrapper.showAndGet()) {
+                myCustomImports.add(
+                        myCustomImports.getSize(),
+                        dialogWrapper.getFieldData()
+                );
+            }
+        };
+        myToolbar.setAddAction(addAction);
+        AnActionButtonRunnable editAction = (AnActionButton actionButton) -> {
+            WGSLAddURLDialogWrapper dialogWrapper =
+                    new WGSLAddURLDialogWrapper(myList.getSelectedValue());
+            if (dialogWrapper.showAndGet()) {
+                myCustomImports.setElementAt(
+                        dialogWrapper.getFieldData(),
+                        myList.getSelectedIndex()
+                );
+            }
+        };
+        myToolbar.setEditAction(editAction);
+
+        myMainPanel = FormBuilder.createFormBuilder()
+                .addLabeledComponentFillVertically("Custom import URLs:", myToolbar.createPanel())
+                .getPanel();
+    }
+
+    public JPanel getPanel() {
+        return myMainPanel;
+    }
+
+    @NotNull
+    public List<String> getCustomImports() {
+        return myCustomImports.getItems();
+    }
+
+    public void setCustomImports(List<String> customImports) {
+        for (String item : customImports) {
+            myCustomImports.add(myCustomImports.getSize(), item);
+        }
+    }
+}

--- a/src/main/java/wgslplugin/language/WGSLSettingsConfigurable.java
+++ b/src/main/java/wgslplugin/language/WGSLSettingsConfigurable.java
@@ -1,0 +1,53 @@
+package wgslplugin.language;
+
+import com.intellij.openapi.options.Configurable;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class WGSLSettingsConfigurable implements Configurable, Configurable.VariableProjectAppLevel, Configurable.NoScroll {
+    private WGSLSettingsComponent mySettingsComponent;
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "WGSL";
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        mySettingsComponent = new WGSLSettingsComponent();
+        return mySettingsComponent.getPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        WGSLSettingsState settings = WGSLSettingsState.getInstance();
+        return !mySettingsComponent.getCustomImports().equals(settings.customImports);
+    }
+
+    @Override
+    public void apply() {
+        WGSLSettingsState settings = WGSLSettingsState.getInstance();
+        settings.customImports = mySettingsComponent.getCustomImports();
+    }
+
+    @Override
+    public void reset() {
+        WGSLSettingsState settings = WGSLSettingsState.getInstance();
+        mySettingsComponent.setCustomImports(settings.customImports);
+    }
+
+    @Override
+    public void disposeUIResources() {
+        mySettingsComponent = null;
+    }
+
+    @Override
+    public boolean isProjectLevel() {
+        return true;
+    }
+}
+

--- a/src/main/java/wgslplugin/language/WGSLSettingsConfigurable.java
+++ b/src/main/java/wgslplugin/language/WGSLSettingsConfigurable.java
@@ -1,13 +1,19 @@
 package wgslplugin.language;
 
 import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
 public class WGSLSettingsConfigurable implements Configurable, Configurable.VariableProjectAppLevel, Configurable.NoScroll {
+    private final Project project;
     private WGSLSettingsComponent mySettingsComponent;
+
+    WGSLSettingsConfigurable(Project project) {
+        this.project = project;
+    }
 
     @Nls(capitalization = Nls.Capitalization.Title)
     @Override
@@ -24,19 +30,19 @@ public class WGSLSettingsConfigurable implements Configurable, Configurable.Vari
 
     @Override
     public boolean isModified() {
-        WGSLSettingsState settings = WGSLSettingsState.getInstance();
+        WGSLSettingsState settings = WGSLSettingsState.getInstance(project);
         return !mySettingsComponent.getCustomImports().equals(settings.customImports);
     }
 
     @Override
     public void apply() {
-        WGSLSettingsState settings = WGSLSettingsState.getInstance();
+        WGSLSettingsState settings = WGSLSettingsState.getInstance(project);
         settings.customImports = mySettingsComponent.getCustomImports();
     }
 
     @Override
     public void reset() {
-        WGSLSettingsState settings = WGSLSettingsState.getInstance();
+        WGSLSettingsState settings = WGSLSettingsState.getInstance(project);
         mySettingsComponent.setCustomImports(settings.customImports);
     }
 

--- a/src/main/java/wgslplugin/language/WGSLSettingsState.java
+++ b/src/main/java/wgslplugin/language/WGSLSettingsState.java
@@ -1,9 +1,9 @@
 package wgslplugin.language;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,13 +13,13 @@ import java.util.List;
 
 @State(
         name = "wgslplugin.language.WGSLSettingsState",
-        storages = @Storage("SdkSettingsPlugin.xml")
+        storages = @Storage("WGSLSettingsPlugin.xml")
 )
 public class WGSLSettingsState implements PersistentStateComponent<WGSLSettingsState> {
     public List<String> customImports = new ArrayList<>();
 
-    public static WGSLSettingsState getInstance() {
-        return ApplicationManager.getApplication().getService(WGSLSettingsState.class);
+    public static WGSLSettingsState getInstance(Project project) {
+        return project.getService(WGSLSettingsState.class);
     }
 
     @Nullable

--- a/src/main/java/wgslplugin/language/WGSLSettingsState.java
+++ b/src/main/java/wgslplugin/language/WGSLSettingsState.java
@@ -1,0 +1,35 @@
+package wgslplugin.language;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@State(
+        name = "wgslplugin.language.WGSLSettingsState",
+        storages = @Storage("SdkSettingsPlugin.xml")
+)
+public class WGSLSettingsState implements PersistentStateComponent<WGSLSettingsState> {
+    public List<String> customImports = new ArrayList<>();
+
+    public static WGSLSettingsState getInstance() {
+        return ApplicationManager.getApplication().getService(WGSLSettingsState.class);
+    }
+
+    @Nullable
+    @Override
+    public WGSLSettingsState getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull WGSLSettingsState state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -49,9 +49,10 @@
                                     implementationClass="wgslplugin.language.WGSLDocumentationProvider"/>
         <completion.contributor language="WGSL" implementationClass="wgslplugin.language.WGSLKeywordCompletionContributor"/>
         <completion.contributor language="WGSL" implementationClass="wgslplugin.language.WGSLBuiltInCompletionContributor"/>
-        <applicationConfigurable parentId="tools" instance="wgslplugin.language.WGSLSettingsConfigurable"
+        <projectConfigurable parentId="tools" instance="wgslplugin.language.WGSLSettingsConfigurable"
             id="wgslplugin.language.WGSLSettingsConfigurable"
-            displayName="WGSL"/>
-        <applicationService serviceImplementation="wgslplugin.language.WGSLSettingsState"/>
+            displayName="WGSL"
+            nonDefaultProject="true"/>
+        <projectService serviceImplementation="wgslplugin.language.WGSLSettingsState"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -49,5 +49,9 @@
                                     implementationClass="wgslplugin.language.WGSLDocumentationProvider"/>
         <completion.contributor language="WGSL" implementationClass="wgslplugin.language.WGSLKeywordCompletionContributor"/>
         <completion.contributor language="WGSL" implementationClass="wgslplugin.language.WGSLBuiltInCompletionContributor"/>
+        <applicationConfigurable parentId="tools" instance="wgslplugin.language.WGSLSettingsConfigurable"
+            id="wgslplugin.language.WGSLSettingsConfigurable"
+            displayName="WGSL"/>
+        <applicationService serviceImplementation="wgslplugin.language.WGSLSettingsState"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Summary

This pull request closes #53 as it introduces a basic `configure URLs -> fetch -> autocomplete` model required for custom [bevy](https://github.com/bevyengine/bevy) shader imports

- a new settings entry `Tools`->`WGSL`
- accepts custom source URL with modal validation
- edit/delete URLs from list
- settings are saved and stored per project
- imports are fetched if settings were changed

<details>
<summary>Screenshots</summary>

<img width="436" alt="image" src="https://user-images.githubusercontent.com/108860307/233822595-14cc5de9-6f6d-4681-b382-50f21179b4d3.png"><img width=5000/> | <img width="436" alt="image" src="https://user-images.githubusercontent.com/108860307/233822747-5a9ed530-e748-4d74-8ec4-6d1f32b61c49.png"><img width=5000/>
|:---:|:---:|
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/108860307/233825555-1d8537b1-cf94-4d24-8541-dac9f7028f48.png"> | <img width="323" alt="image" src="https://user-images.githubusercontent.com/108860307/233825698-3cb16209-fa5a-42a6-b64c-2fc9731243be.png">

</details>

## Caveats

I didn't bundled `WGSLCustomImportsFetcher`'s mapped fields as I understand that they may help in future implementations of context-aware completions, but any other potential flaws may be in my implementation, so please verify that:

- `functions`, `constants`, `variables` and `structs` are enough for `CompletionContributor` as I may have missed some
- a single `fetch` on each `WGSLSettingsState.getInstance().customImports` change is appropriate - I didn't implemented any request or PSI/IDE caching, the only holding factor is `List<String> customImportsCached` in `WGSLCustomImportsFetcher`

## Next steps

Overall, the plugin doesn't look much slower when invoking a first autocomplete after settings change. Still, there is a room for speed and usability improvements:

- completion from `file` and raw `string` data
- storing settings and frequently accessed data in [CachedValuesManager](https://github.com/JetBrains/intellij-community/blob/master/platform/core-api/src/com/intellij/psi/util/CachedValuesManager.java)
- background fetch and processing of imports on settings save while showing [ProgressIndicator](https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html?from=jetbrains.org#background-processes-and-processcanceledexception)
